### PR TITLE
Create overloads for applying color, background, and styles at the same time

### DIFF
--- a/Chalk.swift
+++ b/Chalk.swift
@@ -57,11 +57,15 @@ private extension String.StringInterpolation {
         var codeStrings: [String] = []
         
         if let color = color?.rawValue {
-            codeStrings.append("38;5;\(color)")
+            codeStrings.append("38")
+            codeStrings.append("5")
+            codeStrings.append("\(color)")
         }
         
         if let background = background?.rawValue {
-            codeStrings.append("48;5;\(background)")
+            codeStrings.append("48")
+            codeStrings.append("5")
+            codeStrings.append("\(background)")
         }
         
         if !styles.isEmpty {
@@ -85,12 +89,12 @@ public extension String.StringInterpolation {
         applyChalk(color: nil, background: background, styles: [], to: any)
     }
     
-    mutating func appendInterpolation(_ any: Any, styles: Set<Style>) {
-        applyChalk(color: nil, background: nil, styles: styles, to: any)
-    }
-    
     mutating func appendInterpolation(_ any: Any, style: Style) {
         applyChalk(color: nil, background: nil, styles: [style], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, styles: Set<Style>) {
+        applyChalk(color: nil, background: nil, styles: styles, to: any)
     }
     
     mutating func appendInterpolation(_ any: Any, color: Color, background: Color) {

--- a/Chalk.swift
+++ b/Chalk.swift
@@ -1,12 +1,41 @@
-public enum Color: Int {
-    case black = 30
-    case red = 31
-    case green = 32
-    case yellow = 33
-    case blue = 34
-    case magenta = 35
-    case cyan = 36
-    case white = 37
+public enum Color: RawRepresentable {
+    case black
+    case red
+    case green
+    case yellow
+    case blue
+    case magenta
+    case cyan
+    case white
+    case extended(UInt8)
+    
+    public init?(rawValue: UInt8) {
+        switch rawValue {
+        case 0: self = .black
+        case 1: self = .red
+        case 2: self = .green
+        case 3: self = .yellow
+        case 4: self = .blue
+        case 5: self = .magenta
+        case 6: self = .cyan
+        case 7: self = .white
+        default: self = .extended(rawValue)
+        }
+    }
+    
+    public var rawValue: UInt8 {
+        switch self {
+        case .black: return 0
+        case .red: return 1
+        case .green: return 2
+        case .yellow: return 3
+        case .blue: return 4
+        case .magenta: return 5
+        case .cyan: return 6
+        case .white: return 7
+        case .extended(let number): return number
+        }
+    }
 }
 
 public enum Style: Int {
@@ -20,27 +49,75 @@ public enum Style: Int {
     case strikethrough = 9  // not implemented in Terminal.app
 }
 
-public extension String.StringInterpolation {
-    mutating func appendInterpolation(_ any: Any, color: Color, style: Style? = nil) {
+private extension String.StringInterpolation {
+    mutating func applyChalk(color: Color?, background: Color?, styles: Set<Style>, to any: Any) {
         appendLiteral("\u{001B}[")
-        appendLiteral(String(color.rawValue))
-        if let style = style?.rawValue {
-            appendInterpolation(";\(style)")
+        
+        let codeSeparator = ";"
+        var codeStrings: [String] = []
+        
+        if let color = color?.rawValue {
+            codeStrings.append("38;5;\(color)")
         }
+        
+        if let background = background?.rawValue {
+            codeStrings.append("48;5;\(background)")
+        }
+        
+        if !styles.isEmpty {
+            codeStrings.append(styles.map { "\($0.rawValue)" }.joined(separator: codeSeparator))
+        }
+        
+        appendInterpolation(codeStrings.joined(separator: codeSeparator))
+        
         appendLiteral("m")
         appendInterpolation("\(any)")
-        appendLiteral("\u{001B}[0m")  // resets color
+        appendLiteral("\u{001B}[0m")  // reset color, background, and style
     }
 }
 
 public extension String.StringInterpolation {
-    mutating func appendInterpolation(_ any: Any, color: UInt8, background: UInt8? = nil) {
-        appendInterpolation("\u{001B}[38;5;\(color)")
-        if let bg = background {
-            appendInterpolation(";48;5;\(bg)")
-        }
-        appendLiteral("m")
-        appendInterpolation("\(any)")
-        appendLiteral("\u{001B}[0m")  // resets color
+    mutating func appendInterpolation(_ any: Any, color: Color) {
+        applyChalk(color: color, background: nil, styles: [], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, background: Color) {
+        applyChalk(color: nil, background: background, styles: [], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, styles: Set<Style>) {
+        applyChalk(color: nil, background: nil, styles: styles, to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, style: Style) {
+        applyChalk(color: nil, background: nil, styles: [style], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, color: Color, background: Color) {
+        applyChalk(color: color, background: background, styles: [], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, background: Color, style: Style) {
+        applyChalk(color: nil, background: background, styles: [style], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, background: Color, styles: Set<Style>) {
+        applyChalk(color: nil, background: background, styles: styles, to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, color: Color, style: Style) {
+        applyChalk(color: color, background: nil, styles: [style], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, color: Color, styles: Set<Style>) {
+        applyChalk(color: color, background: nil, styles: styles, to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, color: Color, background: Color, style: Style) {
+        applyChalk(color: color, background: background, styles: [style], to: any)
+    }
+    
+    mutating func appendInterpolation(_ any: Any, color: Color, background: Color, styles: Set<Style>) {
+        applyChalk(color: color, background: background, styles: styles, to: any)
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import Chalk  // @mxcl ~> 0.3
 for x in 0..<256 {
     let cell = " \(x)".padding(toLength: 5, withPad: " ", startingAt: 0)
     let terminator = (x + 3).isMultiple(of: 6) ? "\n" : ""
-    print("\(cell, color: 15, background: UInt8(x))", terminator: terminator)
+    print("\(cell, color: .extended(15), background: .extended(UInt8(x)))", terminator: terminator)
 }
 EOF
 ```


### PR DESCRIPTION
Examples:

```
"\(string, color: .blue)"
"\(string, background: .white)"
"\(string, style: .bold)"
"\(string, styles: [.bold, .italic])"
"\(string, color: .blue, style: .bold)"
"\(string, color: .blue, styles: [.bold, .italic])"
"\(string, color: .blue, background: .white)"
"\(string, background: .white, styles: [.bold, .italic])"
"\(string, color: .blue, background: .white, styles: [.bold, .italic])"
"\(string, color: .extended(34), background: .extended(64), styles: [.bold, .italic])"
```