### PR TITLE
Detect non- and non-color-terminals and skip applying the color styling. Fixes #2

### DIFF
--- a/Chalk.swift
+++ b/Chalk.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 fileprivate let stdOutIsColorTerm: Bool = {
+    if let cliColorForce = ProcessInfo.processInfo.environment["CLICOLOR_FORCE"],
+       ["1", "yes", "true"].contains(cliColorForce) { return true}
     guard isatty(STDOUT_FILENO) == 1 else { return false }
 #if os(macOS)
     if let xpcServiceName = ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"],

--- a/Chalk.swift
+++ b/Chalk.swift
@@ -1,3 +1,18 @@
+import Foundation
+
+fileprivate let stdOutIsColorTerm: Bool = {
+    guard isatty(STDOUT_FILENO) == 1 else { return false }
+#if os(macOS)
+    if let xpcServiceName = ProcessInfo.processInfo.environment["XPC_SERVICE_NAME"],
+       xpcServiceName.localizedCaseInsensitiveContains("com.apple.dt.xcode") {
+        return false
+    }
+#endif
+    guard let term = ProcessInfo.processInfo.environment["TERM"],
+          !["", "dumb", "cons25", "emacs"].contains(term) else { return false }
+    return true
+}()
+
 public enum Color: RawRepresentable {
     case black
     case red
@@ -57,6 +72,7 @@ public struct Style: OptionSet {
 
 private extension String.StringInterpolation {
     mutating func applyChalk(color: Color?, background: Color?, style: Style?, to any: Any) {
+        guard stdOutIsColorTerm else { return appendInterpolation("\(any)") }
         appendLiteral("\u{001B}[")
 
         var codeStrings: [String] = []


### PR DESCRIPTION
Note for the Xcode detection: In earlier versions of Xcode, the environment
variable TERM was correctly unset. More recent versions expose TERM=xterm-256color,
which clearly is wrong, hence we need special treatment to find out whether we're
running within Xcode.